### PR TITLE
Fix registry key creation

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jdunn@getchef.com"
 license          "Apache 2.0"
 description      "Installs Microsoft SysInternals tools"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.1"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,12 +35,13 @@ node['sysinternals']['tools'].each do |toolname,url|
   end
   #disable popup, we accept the EULA!
   # http://peter.hahndorf.eu/blog/2010/03/07/WorkAroundSysinternalsLicensePopups.aspx
-  registry_key "HKEY_CURRENT_USER\Software\Sysinternals\#{toolname}" do
+  registry_key "HKEY_CURRENT_USER\\Software\\Sysinternals\\#{toolname}" do
     values [{
       :name => 'EulaAccepted',
       :type => :dword,
       :data => 1
     }]
     action :create
+    recursive true
   end
 end


### PR DESCRIPTION
When using double quotes the backslashes in the registry keys need to be escaped. Also the path `HKEY_CURRENT_USER\Software\Sysinternals` does not yet exist so we need to ensure `recursive=true` or the creation fails.
