### PR TITLE
Add new recipe to setup the full Sysinternals Suite

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,3 +31,6 @@ default['sysinternals']['tools'] = {
 default['sysinternals']['procexp']['name'] = 'Process Explorer'
 default['sysinternals']['procexp']['url'] =  'http://live.sysinternals.com/procexp.exe'
 default['sysinternals']['procexp']['replace_taskmgr'] = true
+
+default['sysinternals']['full_suite']['url']      = 'http://download.sysinternals.com/files/SysinternalsSuite.zip'
+default['sysinternals']['full_suite']['checksum'] = nil

--- a/recipes/full_suite.rb
+++ b/recipes/full_suite.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook:: sysinternals
+# Recipe:: full_suite
+#
+# Copyright:: 2013-2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+directory node['sysinternals']['install_dir'] do
+  action :create
+end
+
+windows_zipfile node['sysinternals']['install_dir'] do
+  action :unzip
+  source node['sysinternals']['full_suite']['url']
+  checksum node['sysinternals']['full_suite']['checksum'] unless node['sysinternals']['full_suite']['checksum'].nil?
+  not_if { ::File.exist?(::File.join(node['sysinternals']['install_dir'], 'PsExec.exe')) }
+end
+
+windosw_path node['sysinternals']['install_dir']


### PR DESCRIPTION
Add recipe sysinternals::full_suite to setup the complete sysinternals
suite at once.
This recipe reuse the `sysinternals.install_dir` attribute and add
two new attributes to control the suite url and its checksum:
* `sysinternals.full_suite.url`
* `sysinternals.full_suite.checksum`

By default checksum is nil to skip the checksum validation, but it is a good practice to perform this validation.

*Cc.* @aboten
