### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,49 +8,10 @@ name: "Test"
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
       actions: write
       checks: write
       pull-requests: write
       statuses: write
       issues: write
-
-  # TODO: Add integration tests
-  # integration:
-  #   needs: "lint-unit"
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - almalinux-8
-  #         - amazonlinux-2
-  #         - debian-10
-  #         - debian-11
-  #         - centos-7
-  #         - centos-stream-8
-  #         - ubuntu-1804
-  #         - ubuntu-2004
-  #         - ubuntu-2204
-  #         - rockylinux-8
-  #       suite: [default]
-  #     fail-fast: false
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-  #     - name: Install Chef
-  #       uses: actionshub/chef-install@2.0.4
-  #     - name: Dokken
-  #       uses: actionshub/test-kitchen@2.1.0
-  #       env:
-  #         CHEF_LICENSE: accept-no-persist
-  #         KITCHEN_LOCAL_YAML: kitchen.dokken.yml
-  #       with:
-  #         suite: ${{ matrix.suite }}
-  #         os: ${{ matrix.os }}
-
-  # final:
-  #   runs-on: ubuntu-latest
-  #   needs: [integration]
-  #   steps:
-  #     - run: echo ${{needs.integration.outputs}}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,5 @@
+name 'sysinternals'
+
+run_list 'sysinternals::default'
+
+cookbook 'sysinternals', path: '.'

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -4,7 +4,9 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  policyfile_path: Policyfile.rb
 
 platforms:
   - name: almalinux-8

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -1,6 +1,11 @@
 ---
 driver: { name: exec }
 transport: { name: exec }
+provisioner:
+  name: chef_infra
+  product_name: cinc
+  install_strategy: skip
+  policyfile_path: Policyfile.rb
 
 platforms:
   - name: macos-latest

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -5,6 +5,7 @@ provisioner:
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
   install_strategy: once
+  policyfile_path: Policyfile.rb
   chef_license: accept
   enforce_idempotency: <%= ENV['ENFORCE_IDEMPOTENCY'] || true %>
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace Berkshelf with a Policyfile-only dependency setup
- switch ChefSpec and Kitchen provisioners to Policyfile resolution
- update lint-unit reusable workflow to 9.0.0 and remove stale Berkshelf references

## Validation
- chef update Policyfile.rb
- cookstyle (exit 0; existing Chef/Modernize/WindowsZipfileUsage refactor notice remains scoped out)
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- markdownlint-cli2 "**/*.md"
- yamllint .
- actionlint
- git diff --check
- kitchen list / diagnose attempted; repo has no kitchen.yml and no suites, so no Kitchen instances or feasible Kitchen test are available